### PR TITLE
Fix create graphql-modules example (#148)

### DIFF
--- a/packages/create/examples/graphql-modules/package.json
+++ b/packages/create/examples/graphql-modules/package.json
@@ -18,7 +18,6 @@
     "@graphql-modules/core": "0.x",
     "@graphql-modules/di": "0.x",
     "@paljs/plugins": "2.5.4",
-    "@prisma-tools/graphql-modules": "0.x",
     "@prisma/client": "2.x",
     "apollo-server": "2.x",
     "graphql": "15.x",

--- a/packages/create/examples/graphql-modules/tsconfig.json
+++ b/packages/create/examples/graphql-modules/tsconfig.json
@@ -11,7 +11,8 @@
     "sourceMap": true,
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "esModuleInterop": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/packages/plugins/src/sdlInputs.ts
+++ b/packages/plugins/src/sdlInputs.ts
@@ -100,7 +100,7 @@ function createInput(options?: OptionsType) {
   return fileContent;
 }
 
-export const sdlInputs = (options: OptionsType) => gql`
+export const sdlInputs = (options?: OptionsType) => gql`
   ${createInput(options)}
 `;
 


### PR DESCRIPTION
* Add esModuleInterop to tsconfig

* Make sdlInputs plugin options optional

* Remove @prisma-tools/graphql-modules dependency